### PR TITLE
Updated ClassRef Calls to be in-line with Master Commit b266f13

### DIFF
--- a/csharp/SteamMultiplayerPeer.cs
+++ b/csharp/SteamMultiplayerPeer.cs
@@ -23,14 +23,14 @@ public sealed partial class SteamMultiplayerPeer : MultiplayerPeerExtension
         _classReference = ClassDB.Instantiate(stringName).AsGodotObject();
     }
 
-    public Error CreateHost(ushort port, Array options)
+    public Error CreateHost(ushort port)
     {
-        return _classReference.Call(Methods.CreateHost, port, options).As<Error>();
+        return _classReference.Call(Methods.CreateHost, port).As<Error>();
     }
 
-    public Error CreateClient(ulong steamId, ushort port, Array options)
+    public Error CreateClient(ulong steamId, ushort port)
     {
-        return _classReference.Call(Methods.CreateClient, steamId, port, options).As<Error>();
+        return _classReference.Call(Methods.CreateClient, steamId, port).As<Error>();
     }
 
     public override ConnectionStatus _GetConnectionStatus()


### PR DESCRIPTION
Current version of C# bindings do not match with current steam_multiplayer_peer.h in [original project](https://github.com/expressobits/steam-multiplayer-peer).

Removed options parameter from CreateHost and CreateClient to match with current version of the plugin.